### PR TITLE
remove error raising by pipe error

### DIFF
--- a/pulpo/io/tcp.lua
+++ b/pulpo/io/tcp.lua
@@ -80,7 +80,7 @@ local function tcp_read(io, ptr, len)
 	if n <= 0 then
 		if n == 0 then 
 			io:close('remote')
-			raise('pipe')
+			return nil
 		end
 		local eno = errno.errno()
 		if eno == EAGAIN or eno == EWOULDBLOCK then
@@ -162,6 +162,9 @@ local function tcp_accept(io)
 ::retry::
 	-- print('tcp_accept:', io:fd())
 	if not ctx then
+		-- because if C.accept returns any fd, there is no point to yield this funciton.
+		-- so other coroutine which call tcp_accept never intercept this ctx. 
+		-- we can reuse ctx pointer for next accept call.
 		ctx = memory.alloc_typed('pulpo_tcp_context_t')
 		assert(ctx ~= ffi.NULL, "error alloc context")
 	end

--- a/pulpo/poller/epoll.lua
+++ b/pulpo/poller/epoll.lua
@@ -82,7 +82,9 @@ function io_index.fin(t, reason)
 		-- so in pulpo, I don't use dup.
 		-- if 3rdparty lib use dup(), please do it in gc_handler XD
 		-- (just call t:remove_from_poller())
+		local fd = tonumber(t:fd())
 		gc_handlers[t:type()](t)
+		udatalist[fd] = nil
 	end
 end
 io_index.wait_read = event.wait_read

--- a/test/tools/run_bench.sh
+++ b/test/tools/run_bench.sh
@@ -13,6 +13,8 @@ if [ "$2" != "" ]; then
 fi
 if [ "$3" != "" ]; then
 	sed -i s/-h10000/-h$3/g bench.sh
+else
+	sed -i s/-h10000/-h2000/g bench.sh
 fi
 SSL_CMD=
 if [ "$4" != "" ]; then


### PR DESCRIPTION
to fix error on benchmark, we change the behavior of io:read so that is returns nil for pipe error (mainly because of closing remote peer), instead of raise pipe exception.
